### PR TITLE
Allow later pysigma releases

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ packages = [
 
 [tool.poetry.dependencies]
 python = "^3.8"
-pysigma = "^0.5.0"
+pysigma = "^0.6.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.1.1"


### PR DESCRIPTION
`pysigma` 0.6.2 was released a while back. With the current version constraint it's not possible to install `pysigma-pipeline-crowdstrike` in the same `venv` with other `pysigma-*` modules.